### PR TITLE
Update vite.config to allow deployment from both github pages and aws

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,8 +5,8 @@ import vue from '@vitejs/plugin-vue'
 import vueDevTools from 'vite-plugin-vue-devtools'
 
 // https://vite.dev/config/
-export default defineConfig({
-  base: process.env.NODE_ENV === 'production' ? '/portfolio/' : '/',
+export default defineConfig(({ mode }) => ({
+  base: process.env.VITE_BASE_PATH || (mode === 'production' ? '/portfolio/' : '/'),
   plugins: [
     vue(),
     vueDevTools(),
@@ -16,4 +16,4 @@ export default defineConfig({
       '@': fileURLToPath(new URL('./src', import.meta.url))
     },
   },
-})
+}))


### PR DESCRIPTION
- Update vite.config to allow base url to be either "\" or "\portfolio\" depending on whether it's being run in development or production, and deployed (temporarily) on both GitHub Pages and AWS Amplify